### PR TITLE
2つ目の動画の自動再生をオフにした

### DIFF
--- a/_includes/video.html
+++ b/_includes/video.html
@@ -1,13 +1,5 @@
 {% if site.url contains "http://localhost" or site.url contains "http://127.0.0.1" %}
-<video width="100%" src="/usecase-videos/{{ include.id }}.mp4" autoplay controls id="{{ include.id }}"></video>
-{% if include.start %}
-<script>
-  document.getElementById('{{ include.id }}').addEventListener('loadedmetadata', function() {
-console.log(this);
-this.currentTime = {{ include.start }} - 0;
-}, false)
-</script>
-{% endif %}
+<video width="100%" src="/usecase-videos/{{ include.id }}.mp4{% if include.start %}#t={{ include.start }}{% endif %}" {% if include.noautoplay %}preload="auto"{% else %}autoplay{% endif %} controls id="{{ include.id }}"></video>
 {% else %}
-<iframe width="560" height="315" src="https://www.youtube.com/embed/{{ include.id }}?autoplay=1&rel=0{% if include.start %}&start={{ include.start }}{% endif %}" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/{{ include.id }}?{% unless include.noautoplay %}autoplay=1&{% endunless %}rel=0{% if include.start %}&start={{ include.start }}{% endif %}" frameborder="0" allowfullscreen></iframe>
 {% endif %}

--- a/_posts/usecase/2016-08-01-clinics.md
+++ b/_posts/usecase/2016-08-01-clinics.md
@@ -12,7 +12,7 @@ tags: skyway webrtc image usercase support healthcare conf
 
 オンライン通院サービス
 
-{% include video.html id='VcQ4anopXMU' start='421' %}
+{% include video.html id='VcQ4anopXMU' start='421' noautoplay=true %}
 
 安倍総理大臣も体験しました。
 


### PR DESCRIPTION
変更点

- `{% include video.html id='VcQ4anopXMU' start='421' noautoplay=true %}` のように `noautoplay=true` を指定すれば、自動再生をオフにするようにした
- 動画の再生範囲指定の実装を、JavaScriptで `videoElement.currentTime=421;` とする方法から、URLの末尾に `#t=421` と書く方法に変更し、コードを簡潔に & 動作を安定化した

既知の問題

- Chromeで localhost:4000 で表示すると、動画のロードが不安定 (video要素が動画ファイルを読み込まないことがある)

テスト手順

- [ ] http://localhost:4000/skyway/clinics/ (SafariまたはFirefox)
  - [ ] 1番目の動画が36秒から自動再生される (Safari 11は一時停止状態になる)
  - [ ] 2番目の動画が7分1秒にシークされるが、自動再生されない
- [ ] PReqをマージ (コードレビューは不要だと思います)
- [ ] https://webrtc.ecl.ntt.com/usecase/skyway/clinics/ (Chrome)
  - [ ] 1番目の動画が36秒から自動再生される
  - [ ] 2番目の動画が7分1秒にシークされるが、自動再生されない