### PR TITLE
add notice for disclaimer

### DIFF
--- a/_includes/another-company-with.html
+++ b/_includes/another-company-with.html
@@ -1,0 +1,1 @@
+<div class="notice-success">こちらのユースケースは、他社によるWebRTCの活用事例です。<br>WebRTCの幅広いユースケースを知っていただくために記載しています。<br>通信部分にSkyWayのiOS SDKを利用することができます。</div>

--- a/_includes/another-company-with.html
+++ b/_includes/another-company-with.html
@@ -1,1 +1,1 @@
-<div class="notice-success">こちらのユースケースは、他社によるWebRTCの活用事例です。<br>WebRTCの幅広いユースケースを知っていただくために記載しています。<br>通信部分にSkyWayのiOS SDKを利用することができます。</div>
+<div class="notice-success">こちらのユースケースは他社によるWebRTCの活用事例ですが、通信部分にSkyWayのiOS SDKを利用することもできます。<br>WebRTCの幅広いユースケースを知っていただくために記載しています。</div>

--- a/_includes/another-company.html
+++ b/_includes/another-company.html
@@ -1,0 +1,1 @@
+<div class="notice-success">こちらのユースケースは、他社によるWebRTCの活用事例です。<br>WebRTCの幅広いユースケースを知っていただくために記載しています。</div>

--- a/_includes/robot-notice.html
+++ b/_includes/robot-notice.html
@@ -1,1 +1,1 @@
-<div class="notice-success">こちらのユースケースは、通信部分にSkyWayを利用しています。<br>SkyWayのSDKはiOS/Android/JSのみに対応しています。</div>
+<div class="notice-success">こちらのユースケースは、通信部分にSkyWayを利用しています。<br>SkyWayのSDKはiOS/Android/JavaScriptのみに対応しています。</div>

--- a/_includes/robot-notice.html
+++ b/_includes/robot-notice.html
@@ -1,0 +1,1 @@
+<div class="notice-success">こちらのユースケースは、通信部分にSkyWayを利用しています。<br>SkyWayのSDKはiOS/Android/JSのみに対応しています。</div>

--- a/_includes/telexistence-notice.html
+++ b/_includes/telexistence-notice.html
@@ -1,0 +1,1 @@
+<div class="notice-success">こちらのユースケースは、通信部分にSkyWayを利用しています。<br>SkyWayのSDKはiOS/Android/JavaScriptのみに対応しています。<br>SkyWayのiOS/Android SDKは2018年4月現在、Data ChannelのUnreliableモードに未対応です。</div>

--- a/_posts/usecase/2016-07-01-amazon.md
+++ b/_posts/usecase/2016-07-01-amazon.md
@@ -21,3 +21,5 @@ tags: webrtc image usercase support
 従来のように、わざわざ電話をかけたり、LINE、Skype等のアプリに切り替える必要はありません。
 本人確認などの手間も不要になります。
 オペレーターが資料や画面を共有したり、ユーザのカメラを使って周囲の状況を確認したりしながらサポートすることも可能です。
+
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-01-appearin.md
+++ b/_posts/usecase/2016-07-01-appearin.md
@@ -18,3 +18,5 @@ tags: webrtc image usercase conf
 
 
 [https://appear.in/](https://appear.in/){:target="_blank"}
+
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-01-chatwork.md
+++ b/_posts/usecase/2016-07-01-chatwork.md
@@ -19,3 +19,5 @@ ChatWorkは、ビジネスが加速するクラウド会議室で、メール・
 ビデオ会議機能にWebRTCが利用されています。
 
 [http://www.chatwork.com/ja/](http://www.chatwork.com/ja/){:target="_blank"}
+
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-01-facehub.md
+++ b/_posts/usecase/2016-07-01-facehub.md
@@ -16,3 +16,4 @@ FacePeerが開発・提供するビデオチャットプラットフォーム「
 
 [FacePeer](https://www.face-peer.com/index){:target="_blank"}
 
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-01-fbmessenger.md
+++ b/_posts/usecase/2016-07-01-fbmessenger.md
@@ -14,3 +14,4 @@ tags: webrtc image usercase sns
 
 [https://www.messenger.com/about](https://www.messenger.com/about){:target="_blank"}
 
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-01-fuji.md
+++ b/_posts/usecase/2016-07-01-fuji.md
@@ -18,3 +18,5 @@ tags: webrtc image usercase cdn share broadcast
 4KやVR映像を分散DLし、ユーザ同士で共有することで大容量の動画を高速に見ることができる。
 
 [http://fod.fujitv.co.jp/s/fodlabo/](http://fod.fujitv.co.jp/s/fodlabo/){:target="_blank"}
+
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-01-googleduo.md
+++ b/_posts/usecase/2016-07-01-googleduo.md
@@ -18,3 +18,5 @@ WebRTCを利用しており、受信側は、相手の映像を見ながら応�
 
 
 [https://duo.google.com/](https://duo.google.com/){:target="_blank"}
+
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-01-googlehangouts.md
+++ b/_posts/usecase/2016-07-01-googlehangouts.md
@@ -19,3 +19,4 @@ tags: webrtc image usercase sns
 
 [https://hangouts.google.com/](https://hangouts.google.com/){:target="_blank"}
 
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-01-icamhd.md
+++ b/_posts/usecase/2016-07-01-icamhd.md
@@ -16,3 +16,5 @@ tags: webrtc image usercase iot
 ### 株式会社マザーツール あんしんカム iCam HD 360  
 
 [http://www.mothertool.co.jp/icamhd/](http://www.mothertool.co.jp/icamhd/){:target="_blank"}
+
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-01-rakuten.md
+++ b/_posts/usecase/2016-07-01-rakuten.md
@@ -21,3 +21,4 @@ tags: webrtc image usercase support
 
 [http://www.rakuten-life.co.jp/videochat/](http://www.rakuten-life.co.jp/videochat/){:target="_blank"}
 
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-01-skype.md
+++ b/_posts/usecase/2016-07-01-skype.md
@@ -17,3 +17,5 @@ tags: webrtc image usercase conf sns
 SkypeのWeb版では、WebRTCが活用されている
 
 [Skype for Web](https://web.skype.com/){:target="_blank"}
+
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-01-withings.md
+++ b/_posts/usecase/2016-07-01-withings.md
@@ -18,3 +18,5 @@ tags: webrtc image usercase iot
 ### Withings Home
 
 [https://www.withings.com/jp/ja/products/home](https://www.withings.com/jp/ja/products/home){:target="_blank"}
+
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-01-withings.md
+++ b/_posts/usecase/2016-07-01-withings.md
@@ -4,7 +4,7 @@ title: Withings Home
 excerpt: 
 image:
   teaser: thumbnail/withings_400x250.png
-categories: skyway
+categories: webrtc
 tags: webrtc image usercase iot
 ---
 

--- a/_posts/usecase/2016-07-01-zoen.md
+++ b/_posts/usecase/2016-07-01-zoen.md
@@ -11,3 +11,5 @@ tags: webrtc image usercase education
 {% include video.html id='DX0O7zxgnUU' %}
 
 [https://www.thezoen.com/](https://www.thezoen.com/){:target="_blank"}
+
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-15-gitai.md
+++ b/_posts/usecase/2016-07-15-gitai.md
@@ -15,3 +15,5 @@ tags: webrtc image usercase robot iot vrar
 VR×ロボット領域のスタートアップ「MacroSpace Inc.(マクロスペース)」が、自分の分身のように遠隔操作できるロボット「GITAI」と専用OS「GITAI OS」を開発しています。
 
 [http://gitai.tech](http://gitai.tech){:target="_blank"}
+
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-15-hug.md
+++ b/_posts/usecase/2016-07-15-hug.md
@@ -20,3 +20,5 @@ tags: webrtc image usercase vrar
 [HUG Project](https://hugproject.net){:target="_blank"}
 
 [Ducklings Inc.](https://ducklings.jp){:target="_blank"}
+
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-15-mixer.md
+++ b/_posts/usecase/2016-07-15-mixer.md
@@ -20,3 +20,5 @@ WebRTCを使い、遅延がほぼゼロのリアルタイム配信を特徴と�
 
 Microsoftが2016年に買収。
 Xbox OneのやWindows 10に標準で組み込まれている。
+
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-15-msad.md
+++ b/_posts/usecase/2016-07-15-msad.md
@@ -22,3 +22,5 @@ FacePeer社のビデオチャットプラットフォームとして「FaceHub�
 [三井住友海上火災](http://www.ms-ins.com/){:target="_blank"}
 
 [FacePeer](https://www.face-peer.com/index){:target="_blank"}
+
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-15-nhk.md
+++ b/_posts/usecase/2016-07-15-nhk.md
@@ -22,3 +22,5 @@ tags: webrtc image usercase broadcast vrar
 </figure>
 
 [https://www.nhk.or.jp/strl/open2017/tenji/5.html](https://www.nhk.or.jp/strl/open2017/tenji/5.html){:target="_blank"}
+
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-15-peer5.md
+++ b/_posts/usecase/2016-07-15-peer5.md
@@ -18,3 +18,5 @@ tags: webrtc image usercase cdn share broadcast
 2016年9月に、動画共有サイトDailymotionとの提携を発表。
 
 [Webサイト](https://www.peer5.com){:target="_blank"}
+
+{% include another-company.html %}

--- a/_posts/usecase/2016-07-16-ika.md
+++ b/_posts/usecase/2016-07-16-ika.md
@@ -19,3 +19,5 @@ tags: webrtc image usercase broadcast game noskyway
 個人開発者が開発・提供しています。
 
 [イカデンワ](https://ikadenwa.ink/){:target="blank"}
+
+{% include another-company.html %}

--- a/_posts/usecase/2016-08-01-asics.md
+++ b/_posts/usecase/2016-08-01-asics.md
@@ -6,6 +6,7 @@ image:
   teaser: thumbnail/asics_400x250.png
 categories: skyway
 tags: skyway webrtc image usercase robot iot vrar
+published: false
 ---
 
 <figure class="half">

--- a/_posts/usecase/2016-08-01-double.md
+++ b/_posts/usecase/2016-08-01-double.md
@@ -20,3 +20,5 @@ tags: skyway webrtc image usercase robot iot
 ロボット側にiPadが付いており、iPadのカメラ映像を確認しながら、遠隔地からの操作や通話が可能。
 
 [http://www.doublerobotics.com/](http://www.doublerobotics.com/){:target="_blank"}
+
+{% include another-company-with.html %}

--- a/_posts/usecase/2016-08-01-eartheyes.md
+++ b/_posts/usecase/2016-08-01-eartheyes.md
@@ -21,3 +21,5 @@ tags: skyway webrtc image usercase iot
 カメラ映像の送信と双方向での音声通信にWebRTCを活用
 
 [http://earth-eyes.co.jp/?p=1](http://earth-eyes.co.jp/?p=1){:target="_blank"}
+
+{% include robot-notice.html %}

--- a/_posts/usecase/2016-08-01-ecc.md
+++ b/_posts/usecase/2016-08-01-ecc.md
@@ -3,9 +3,9 @@ layout: article
 title: ECCオンライン英会話
 excerpt: 
 image:
-  teaser: thumbnail/another_ecc_400x250.png
-categories: webrtc
-tags: webrtc image usercase education conf
+  teaser: thumbnail/ecc_400x250.png
+categories: skyway
+tags: skyway webrtc image usercase education conf
 ---
 
 <figure>

--- a/_posts/usecase/2016-08-01-miraikan.md
+++ b/_posts/usecase/2016-08-01-miraikan.md
@@ -18,9 +18,12 @@ tags: skyway webrtc image usercase education robot iot
 
 “おや？”っこひろばで遊ぶ子どもの様子を、ロボットを使って離れた場所から見守るイベント
 
+{% include robot-notice.html %}
+
 
 <div class="tiles">
 {% for post in site.tags.romo %}
   {% include post-grid.html %}
 {% endfor %}
 </div><!-- /.tiles -->
+

--- a/_posts/usecase/2016-08-01-newphoria.md
+++ b/_posts/usecase/2016-08-01-newphoria.md
@@ -18,3 +18,5 @@ tags: skyway webrtc image usercase conf support iot
 <figure>
 	<img src="{{ site.url | replace_first: 'http://', '//' | replace_first: 'https://', '//' }}{{ site.baseurl }}/images/pages/newphoriaWebSky-Translation.png">
 </figure>
+
+{% include robot-notice.html %}

--- a/_posts/usecase/2016-08-01-nexco-sys.md
+++ b/_posts/usecase/2016-08-01-nexco-sys.md
@@ -20,3 +20,5 @@ tags: skyway webrtc image usercase iot remote
 エキスパートが遠隔地から作業者を支援することで、品質と安全性を高め、効率的な点検作業が実施可能となる
 
 [インスペクショングラス パンフレットPDF](http://www.nexco-sys.co.jp/cms/wp-content/uploads/2015/11/1906f0253878074161532d6bce17692b3.pdf){:target="_blank"}
+
+{% include robot-notice.html %}

--- a/_posts/usecase/2016-08-01-romo.md
+++ b/_posts/usecase/2016-08-01-romo.md
@@ -17,3 +17,5 @@ tags: skyway webrtc image usercase robot iot romo
 ビデオ通話機能を備えた遠隔操作ロボット
 
 キャタピラに載せたiPhoneのカメラ映像を遠隔地から確認しながら、操作することができる。
+
+{% include another-company-with.html %}

--- a/_posts/usecase/2016-08-01-telexistence.md
+++ b/_posts/usecase/2016-08-01-telexistence.md
@@ -21,3 +21,5 @@ tags: skyway webrtc image usercase robot iot vrar
     ※このテレイグジスタンスロボットはWebRTCに未対応です
   </caption>
 </figure>
+
+{% include robot-notice.html %}

--- a/_posts/usecase/2016-08-01-telexistence.md
+++ b/_posts/usecase/2016-08-01-telexistence.md
@@ -22,4 +22,4 @@ tags: skyway webrtc image usercase robot iot vrar
   </caption>
 </figure>
 
-{% include robot-notice.html %}
+{% include telexistence-notice.html %}

--- a/_posts/usecase/2016-08-01-uniadex.md
+++ b/_posts/usecase/2016-08-01-uniadex.md
@@ -14,3 +14,5 @@ tags: skyway webrtc image usercase iot remote
 
 > 遠隔地の作業員に向けた、技術支援の実証実験を開始しました。  
 サービスの品質を保ちながら作業効率を上げ、お客さまへより良いサポートサービスの提供を目指します。
+
+{% include robot-notice.html %}

--- a/_posts/usecase/2016-08-01-v-sido.md
+++ b/_posts/usecase/2016-08-01-v-sido.md
@@ -13,4 +13,6 @@ tags: skyway webrtc image usercase robot iot
 
 ### アスラテック V-Sido OS
 
-人型ロボットを制御するOSの遠隔制御機能に採用
+人型ロボットを制御するOSの遠隔制御機能に採用されました。
+
+{% include robot-notice.html %}

--- a/_posts/usecase/2016-09-01-fuso.md
+++ b/_posts/usecase/2016-09-01-fuso.md
@@ -23,3 +23,6 @@ tags: skyway webrtc image usercase iot remote
 このシステムは、川崎の本社にあるテクニカルインフォメーションセンターと連携することができ、適切な整備についてのアドバイスを行い、お客様の車両の整備を迅速に対応することが可能となります。
 
 [ニュースリリース](http://www.mitsubishi-fuso.com/oa/jp/news/news_content/161226/161226.html){:target="_blank"}
+
+{% include robot-notice.html %}
+

--- a/_posts/usecase/2016-09-01-ifogcloud.md
+++ b/_posts/usecase/2016-09-01-ifogcloud.md
@@ -11,3 +11,5 @@ tags: skyway webrtc image usercase iot
 <figure>
 	<img src="{{ site.url | replace_first: 'http://', '//' | replace_first: 'https://', '//' }}{{ site.baseurl }}/images/pages/ifogcloud.png">
 </figure>
+
+{% include robot-notice.html %}

--- a/_posts/usecase/2016-09-01-petoco.md
+++ b/_posts/usecase/2016-09-01-petoco.md
@@ -5,12 +5,12 @@ excerpt:
 image:
   teaser: thumbnail/petoco_400x250.png
 categories: skyway
-tags: skyway webrtc image usercase robot iot romo
+tags: skyway webrtc image usercase robot iot
 ---
 
 ### NTTドコモ
 
-{% include video.html id='13X6cg7R3Po' start='60' %}
+{% include video.html id='1wg5NEHiquo' start='0' %}
 
 時間的・距離的に離れている家族間のコミュニケーションをサポートするホームコミュニケーションデバイス。
 
@@ -30,3 +30,5 @@ tags: skyway webrtc image usercase robot iot romo
 [petoco](http://www.petoco.jp/){:target="_blank"}
 
 [ニュースリリース](https://www.nttdocomo.co.jp/info/news_release/2017/05/24_07.html){:target="_blank"}
+
+{% include robot-notice.html %}


### PR DESCRIPTION
ユースケースサイトに注意書きを追記しました。

量が多いので、以下、コピペでサボってます。間違ってたらすみません。

- rename(ECCのskyway利用開始)
	- [ ] D usecase/2016-07-01-ecc.md
	- [ ] usecase/2016-08-01-ecc.md
- 非表示に変更
	- [ ] usecase/2016-08-01-asics.md
- 他社事例の注意
	- [ ] usecase/2016-07-01-amazon.md
	- [ ] usecase/2016-07-01-appearin.md
	- [ ] usecase/2016-07-01-chatwork.md
	- [ ] usecase/2016-07-01-facehub.md
	- [ ] usecase/2016-07-01-fbmessenger.md
	- [ ] usecase/2016-07-01-fuji.md
	- [ ] usecase/2016-07-01-googleduo.md
	- [ ] usecase/2016-07-01-googlehangouts.md
	- [ ] usecase/2016-07-01-icamhd.md
	- [ ] usecase/2016-07-01-rakuten.md
	- [ ] usecase/2016-07-01-skype.md
	- [ ] usecase/2016-07-01-withings.md
	- [ ] usecase/2016-07-01-zoen.md
	- [ ] usecase/2016-07-15-gitai.md
	- [ ] usecase/2016-07-15-hug.md
	- [ ] usecase/2016-07-15-mixer.md
	- [ ] usecase/2016-07-15-msad.md
	- [ ] usecase/2016-07-15-nhk.md
	- [ ] usecase/2016-07-15-peer5.md
	- [ ] usecase/2016-07-16-ika.md
- 他社事例であり、SkyWay iOS SDKで利用できる
	- [ ] usecase/2016-08-01-double.md
	- [ ] usecase/2016-08-01-romo.md
- robot/IoT/VRAR系で対応SDKを記載
	- [ ] usecase/2016-08-01-eartheyes.md
	- [ ] usecase/2016-08-01-miraikan.md
	- [ ] usecase/2016-08-01-newphoria.md
	- [ ] usecase/2016-08-01-nexco-sys.md
	- [ ] usecase/2016-08-01-telexistence.md
	- [ ] usecase/2016-08-01-uniadex.md
	- [ ] usecase/2016-08-01-v-sido.md
	- [ ] usecase/2016-09-01-fuso.md
	- [ ] usecase/2016-09-01-ifogcloud.md
	- [ ] usecase/2016-09-01-petoco.md
		- youtubeの動画idは差し替えました。ローカルのビデオはまだです