### PR TITLE
Add notice fixes

### DIFF
--- a/_includes/another-company-with.html
+++ b/_includes/another-company-with.html
@@ -1,1 +1,1 @@
-<div class="notice-success">こちらのユースケースは、他社によるWebRTCの活用事例です。<br>WebRTCの幅広いユースケースを知っていただくために記載しています。<br>通信部分にSkyWayのiOS SDKを利用することができます。</div>
+<div class="notice-success">こちらのユースケースは他社によるWebRTCの活用事例ですが、通信部分にSkyWayのiOS SDKを利用することもできます。<br>WebRTCの幅広いユースケースを知っていただくために記載しています。</div>

--- a/_includes/robot-notice.html
+++ b/_includes/robot-notice.html
@@ -1,1 +1,1 @@
-<div class="notice-success">こちらのユースケースは、通信部分にSkyWayを利用しています。<br>SkyWayのSDKはiOS/Android/JSのみに対応しています。</div>
+<div class="notice-success">こちらのユースケースは、通信部分にSkyWayを利用しています。<br>SkyWayのSDKはiOS/Android/JavaScriptのみに対応しています。</div>

--- a/_includes/telexistence-notice.html
+++ b/_includes/telexistence-notice.html
@@ -1,0 +1,1 @@
+<div class="notice-success">こちらのユースケースは、通信部分にSkyWayを利用しています。<br>SkyWayのSDKはiOS/Android/JavaScriptのみに対応しています。<br>SkyWayのiOS/Android SDKは2018年4月現在、Data ChannelのUnreliableモードに未対応です。</div>

--- a/_posts/usecase/2016-07-01-withings.md
+++ b/_posts/usecase/2016-07-01-withings.md
@@ -4,7 +4,7 @@ title: Withings Home
 excerpt: 
 image:
   teaser: thumbnail/withings_400x250.png
-categories: skyway
+categories: webrtc
 tags: webrtc image usercase iot
 ---
 

--- a/_posts/usecase/2016-08-01-telexistence.md
+++ b/_posts/usecase/2016-08-01-telexistence.md
@@ -22,4 +22,4 @@ tags: skyway webrtc image usercase robot iot vrar
   </caption>
 </figure>
 
-{% include robot-notice.html %}
+{% include telexistence-notice.html %}


### PR DESCRIPTION
以下の点を追加で変更します。

- [x] usecase/2016-07-01-withings.md の category が間違ってたので修正 (以前からの間違い)
- [x] Romo / Double 向けの説明を「SkyWayのiOS SDKを利用することができます」→「SkyWayのiOS SDKを利用すること **も** できます」に変更
- [x] ロボット向けの説明で、「JS」→「JavaScript」に変更
- [x] テレイグジスタンスロボット向けには、「SkyWayのiOS/Android SDKは2018年4月現在、Data ChannelのUnreliableモードに未対応です」という説明を追加。テレイグジスタンスロボットの研究者が誤解することを防止するため。